### PR TITLE
refactor: Centralize app management logic into a new module

### DIFF
--- a/APP_TYPES.md
+++ b/APP_TYPES.md
@@ -1,0 +1,43 @@
+# Application Architecture
+
+This document outlines the different types of applications within this project, their location in the codebase, and how they are managed.
+
+The core logic for managing and launching all app types has been centralized in the `window/app/` module. This module is responsible for differentiating between app types and delegating to the appropriate launcher.
+
+---
+
+## 1. System Apps
+
+System Apps are core components of the desktop experience that are critical for the shell's functionality.
+
+-   **Definition:** High-privilege, essential applications. The user has specified that these should be treated with care and not be modified without good reason.
+-   **Examples:** `FileExplorer`, `Settings`, `AppStore`.
+-   **Location:** The component logic for these apps resides alongside other major window components (e.g., in `window/components/`).
+-   **Management Logic:** The logic for launching and managing System Apps is located in `window/app/system.ts`. Currently, they are launched similarly to Internal Apps, but having a separate module allows for specialized logic in the future (e.g., preventing them from being closed, running with special permissions).
+
+---
+
+## 2. Internal Apps
+
+Internal Apps are applications that run as React components within the main Electron window. They represent standard, sandboxed applications.
+
+-   **Definition:** A standard application whose UI is built with React and rendered inside a managed `AppWindow`.
+-   **Examples:** `Notebook`, `SFTP`, `Hyper`.
+-   **Location:** The source code for these applications is typically found in `window/components/apps/`.
+-   **Management Logic:** The logic for launching, focusing, and managing the lifecycle of these apps is located in `window/app/internal.ts`. This includes creating new window instances and ensuring only one instance of an app (that doesn't expect `initialData`) is open at a time.
+
+---
+
+## 3. External Apps
+
+External Apps are separate, self-contained programs (often their own Electron apps) that are launched as child processes from the main application.
+
+-   **Definition:** A standalone application, typically with its own `package.json` and start script (`npm start`). The App Store is capable of recognizing these apps and installing their dependencies (`npm install`).
+-   **Examples:** `Chrome2`, `Chrome3`.
+-   **Location:** The source code for these applications is located in `components/apps/`.
+-   **Management Logic:** The logic for launching these external processes is located in `window/app/external.ts`.
+-   **Important Note:** The user has indicated that this functionality is **currently not working correctly**. The code has been refactored into the new module, but the underlying bug has not been fixed, as per the instruction to focus on refactoring first.
+
+---
+
+This new modular structure in `window/app/` should make it easier to understand, maintain, and extend the application management system in the future.

--- a/window/app/external.ts
+++ b/window/app/external.ts
@@ -1,0 +1,35 @@
+import {AppDefinition} from '../types';
+
+/**
+ * Launches an external application.
+ * This can be a separate Electron app or any executable.
+ * It first tries to use the Electron IPC 'launchExternalApp' if available (in desktop mode),
+ * otherwise it falls back to a local API server call.
+ *
+ * NOTE: This function does not currently work as intended in the original codebase.
+ * It is being moved here as part of a refactoring effort, not a bug fix.
+ *
+ * @param appDef The definition of the external app to launch.
+ */
+export function launchExternalApp(appDef: AppDefinition): void {
+  if (!appDef.isExternal || !appDef.externalPath) {
+    console.error('Invalid app definition for external launch.', appDef);
+    return;
+  }
+
+  if (window.electronAPI?.launchExternalApp) {
+    window.electronAPI.launchExternalApp(appDef.externalPath);
+  } else {
+    // Fallback for web environment (headless server mode)
+    fetch('http://localhost:3001/api/launch', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({path: appDef.externalPath}),
+    }).catch(error => {
+      console.error('Failed to launch external app via API:', error);
+      alert(
+        'Failed to launch application. Ensure the backend server is running.'
+      );
+    });
+  }
+}

--- a/window/app/index.ts
+++ b/window/app/index.ts
@@ -1,0 +1,59 @@
+import {launchExternalApp} from './external';
+import {launchInternalApp} from './internal';
+import {launchSystemApp} from './system';
+import {AppDefinition} from '../types';
+
+// A more robust app management module would define its own types
+// and not depend on React hooks directly, but for this refactoring,
+// we keep the dependency signature from useWindowManager.
+type WindowManagerDeps = any; // Using 'any' for now to avoid duplicating the large type.
+
+const SYSTEM_APP_IDS = ['fileExplorer', 'settings', 'appStore'];
+
+/**
+ * A centralized function to open any type of application.
+ * It determines the app type and delegates to the appropriate launcher.
+ * @param appIdentifier The ID or definition of the app to open.
+ * @param deps The state and setters from the managing hook.
+ * @param appDefinitions The list of all available app definitions.
+ * @param initialData Optional data to pass to the new app instance.
+ */
+export function openApp(
+  appIdentifier: string | AppDefinition,
+  deps: WindowManagerDeps,
+  appDefinitions: AppDefinition[],
+  initialData?: any
+) {
+  let appDef: AppDefinition | undefined;
+
+  if (typeof appIdentifier === 'string') {
+    appDef = appDefinitions.find(app => app.id === appIdentifier);
+  } else {
+    // This handles cases where a partial AppDefinition is passed
+    const potentialAppDef = appIdentifier as any;
+    if (potentialAppDef.path && !potentialAppDef.externalPath) {
+      potentialAppDef.externalPath = potentialAppDef.path;
+    }
+    appDef = potentialAppDef;
+  }
+
+  if (!appDef) {
+    const id =
+      typeof appIdentifier === 'string'
+        ? appIdentifier
+        : JSON.stringify(appIdentifier);
+    console.error(`App with identifier "${id}" not found or invalid.`);
+    return;
+  }
+
+  if (appDef.isExternal) {
+    launchExternalApp(appDef);
+  } else if (SYSTEM_APP_IDS.includes(appDef.id)) {
+    launchSystemApp(appDef, deps, initialData);
+  } else {
+    launchInternalApp(appDef, deps, initialData);
+  }
+}
+
+// Re-exporting the individual launchers in case they are needed directly.
+export {launchExternalApp, launchInternalApp, launchSystemApp};

--- a/window/app/internal.ts
+++ b/window/app/internal.ts
@@ -1,0 +1,116 @@
+import {OpenApp, AppDefinition} from '../types';
+import {
+  DEFAULT_WINDOW_WIDTH,
+  DEFAULT_WINDOW_HEIGHT,
+  TASKBAR_HEIGHT,
+} from '../constants';
+
+type WindowManagerDeps = {
+  openApps: OpenApp[];
+  setOpenApps: React.Dispatch<React.SetStateAction<OpenApp[]>>;
+  activeAppInstanceId: string | null;
+  setActiveAppInstanceId: React.Dispatch<React.SetStateAction<string | null>>;
+  nextZIndex: number;
+  setNextZIndex: React.Dispatch<React.SetStateAction<number>>;
+  desktopRef: React.RefObject<HTMLDivElement>;
+  getNextPosition: (appWidth: number, appHeight: number) => {x: number; y: number};
+};
+
+function getNextPosition(
+  deps: WindowManagerDeps,
+  appWidth: number,
+  appHeight: number
+) {
+  return deps.getNextPosition(appWidth, appHeight);
+}
+
+/**
+ * Launches an internal application, which is a React component rendered inside a window.
+ * Handles focusing existing windows or creating a new one.
+ * @param appDef The definition of the app to launch.
+ * @param deps The state and setters from the managing hook.
+ * @param initialData Optional data to pass to the new app instance.
+ */
+export function launchInternalApp(
+  appDef: AppDefinition,
+  deps: WindowManagerDeps,
+  initialData?: any
+): void {
+  const {
+    openApps,
+    setOpenApps,
+    setActiveAppInstanceId,
+    nextZIndex,
+    setNextZIndex,
+  } = deps;
+
+  if (!appDef.id) {
+    console.error('Cannot open internal app without an ID.', appDef);
+    return;
+  }
+
+  // If not passing specific data, check if a non-minimized instance already exists.
+  if (!initialData) {
+    const existingAppInstance = openApps.find(
+      app => app.id === appDef.id && !app.isMinimized
+    );
+    if (existingAppInstance) {
+      // Bring existing window to front
+      const newZIndex = nextZIndex + 1;
+      setNextZIndex(newZIndex);
+      setOpenApps(prev =>
+        prev.map(app =>
+          app.instanceId === existingAppInstance.instanceId
+            ? {...app, zIndex: newZIndex, isMinimized: false}
+            : app
+        )
+      );
+      setActiveAppInstanceId(existingAppInstance.instanceId);
+      return;
+    }
+
+    // Check for a minimized instance
+    const minimizedInstance = openApps.find(
+      app => app.id === appDef.id && app.isMinimized
+    );
+    if (minimizedInstance) {
+      // Un-minimize it and bring to front
+      const newZIndex = nextZIndex + 1;
+      setNextZIndex(newZIndex);
+      setOpenApps(prev =>
+        prev.map(a => {
+          if (a.instanceId === minimizedInstance.instanceId) {
+            return {...a, isMinimized: false, zIndex: newZIndex};
+          }
+          return a;
+        })
+      );
+      setActiveAppInstanceId(minimizedInstance.instanceId);
+      return;
+    }
+  }
+
+  // Create a new app instance
+  const instanceId = `${appDef.id}-${Date.now()}`;
+  const newZIndex = nextZIndex + 1;
+  setNextZIndex(newZIndex);
+
+  const defaultWidth = appDef.defaultSize?.width || DEFAULT_WINDOW_WIDTH;
+  const defaultHeight = appDef.defaultSize?.height || DEFAULT_WINDOW_HEIGHT;
+
+  const newApp: OpenApp = {
+    ...appDef,
+    icon: appDef.icon,
+    instanceId,
+    zIndex: newZIndex,
+    position: getNextPosition(deps, defaultWidth, defaultHeight),
+    size: {width: defaultWidth, height: defaultHeight},
+    isMinimized: false,
+    isMaximized: false,
+    title: appDef.name,
+    initialData: initialData,
+  };
+
+  setOpenApps(currentOpenApps => [...currentOpenApps, newApp]);
+  setActiveAppInstanceId(instanceId);
+}

--- a/window/app/system.ts
+++ b/window/app/system.ts
@@ -1,0 +1,119 @@
+import {OpenApp, AppDefinition} from '../types';
+import {
+  DEFAULT_WINDOW_WIDTH,
+  DEFAULT_WINDOW_HEIGHT,
+  TASKBAR_HEIGHT,
+} from '../constants';
+
+// This type is duplicated from internal.ts. In a future refactor,
+// this could be moved to a shared types file within the window/app module.
+type WindowManagerDeps = {
+  openApps: OpenApp[];
+  setOpenApps: React.Dispatch<React.SetStateAction<OpenApp[]>>;
+  activeAppInstanceId: string | null;
+  setActiveAppInstanceId: React.Dispatch<React.SetStateAction<string | null>>;
+  nextZIndex: number;
+  setNextZIndex: React.Dispatch<React.SetStateAction<number>>;
+  desktopRef: React.RefObject<HTMLDivElement>;
+  getNextPosition: (appWidth: number, appHeight: number) => {x: number; y: number};
+};
+
+function getNextPosition(
+  deps: WindowManagerDeps,
+  appWidth: number,
+  appHeight: number
+) {
+  return deps.getNextPosition(appWidth, appHeight);
+}
+
+/**
+ * Launches a system application.
+ * Currently, the logic is identical to launching an internal app, but it is separated
+ * into its own function to allow for future specialization, as requested.
+ * @param appDef The definition of the app to launch.
+ * @param deps The state and setters from the managing hook.
+ * @param initialData Optional data to pass to the new app instance.
+ */
+export function launchSystemApp(
+  appDef: AppDefinition,
+  deps: WindowManagerDeps,
+  initialData?: any
+): void {
+  const {
+    openApps,
+    setOpenApps,
+    setActiveAppInstanceId,
+    nextZIndex,
+    setNextZIndex,
+  } = deps;
+
+  if (!appDef.id) {
+    console.error('Cannot open system app without an ID.', appDef);
+    return;
+  }
+
+  // If not passing specific data, check if a non-minimized instance already exists.
+  if (!initialData) {
+    const existingAppInstance = openApps.find(
+      app => app.id === appDef.id && !app.isMinimized
+    );
+    if (existingAppInstance) {
+      // Bring existing window to front
+      const newZIndex = nextZIndex + 1;
+      setNextZIndex(newZIndex);
+      setOpenApps(prev =>
+        prev.map(app =>
+          app.instanceId === existingAppInstance.instanceId
+            ? {...app, zIndex: newZIndex, isMinimized: false}
+            : app
+        )
+      );
+      setActiveAppInstanceId(existingAppInstance.instanceId);
+      return;
+    }
+
+    // Check for a minimized instance
+    const minimizedInstance = openApps.find(
+      app => app.id === appDef.id && app.isMinimized
+    );
+    if (minimizedInstance) {
+      // Un-minimize it and bring to front
+      const newZIndex = nextZIndex + 1;
+      setNextZIndex(newZIndex);
+      setOpenApps(prev =>
+        prev.map(a => {
+          if (a.instanceId === minimizedInstance.instanceId) {
+            return {...a, isMinimized: false, zIndex: newZIndex};
+          }
+          return a;
+        })
+      );
+      setActiveAppInstanceId(minimizedInstance.instanceId);
+      return;
+    }
+  }
+
+  // Create a new app instance
+  const instanceId = `${appDef.id}-${Date.now()}`;
+  const newZIndex = nextZIndex + 1;
+  setNextZIndex(newZIndex);
+
+  const defaultWidth = appDef.defaultSize?.width || DEFAULT_WINDOW_WIDTH;
+  const defaultHeight = appDef.defaultSize?.height || DEFAULT_WINDOW_HEIGHT;
+
+  const newApp: OpenApp = {
+    ...appDef,
+    icon: appDef.icon,
+    instanceId,
+    zIndex: newZIndex,
+    position: getNextPosition(deps, defaultWidth, defaultHeight),
+    size: {width: defaultWidth, height: defaultHeight},
+    isMinimized: false,
+    isMaximized: false,
+    title: appDef.name,
+    initialData: initialData,
+  };
+
+  setOpenApps(currentOpenApps => [...currentOpenApps, newApp]);
+  setActiveAppInstanceId(instanceId);
+}


### PR DESCRIPTION
Creates a new, dedicated module at `window/app` to handle all application launching and management logic.

- Separates the logic for System, Internal, and External apps into their own files (`system.ts`, `internal.ts`, `external.ts`) for clarity and future extensibility.
- Refactors the `useWindowManager` hook to delegate to this new module, significantly simplifying the hook itself.
- Adds an `APP_TYPES.md` document to explain the new architecture and the different categories of applications within the project.

This change improves modularity and makes the app management system easier to understand and maintain.