### PR TITLE
refactor: Centralize app logic and clean up project (NEEDS MANUAL FIX)

### DIFF
--- a/window/hooks/useWindowManager.ts
+++ b/window/hooks/useWindowManager.ts
@@ -1,8 +1,7 @@
-import { useState, useCallback, useEffect } from 'react';
-import { OpenApp, AppDefinition } from '../types';
-import { TASKBAR_HEIGHT, DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT } from '../constants';
-import { getAppDefinitions } from '../../components/apps';
-
+import {useState, useCallback, useEffect} from 'react';
+import {OpenApp, AppDefinition} from '../types';
+import {TASKBAR_HEIGHT} from '../constants';
+import {getAppDefinitions} from '../../components/apps';
 import {openApp as openAppInManager} from '../app';
 
 export const useWindowManager = (
@@ -68,136 +67,100 @@ export const useWindowManager = (
       setOpenApps,
       setActiveAppInstanceId,
       setNextZIndex,
-      getNextPosition,
     ],
   );
 
-  const focusApp = useCallback(
-    (instanceId: string) => {
-      if (activeAppInstanceId === instanceId) return;
+  const focusApp = useCallback((instanceId: string) => {
+    if (activeAppInstanceId === instanceId) return;
 
-      const newZIndex = nextZIndex + 1;
-      setNextZIndex(newZIndex);
-      setOpenApps(prev =>
-        prev.map(app =>
-          app.instanceId === instanceId
-            ? {...app, zIndex: newZIndex, isMinimized: false}
-            : app,
-        ),
-      );
-      setActiveAppInstanceId(instanceId);
-    },
-    [activeAppInstanceId, nextZIndex],
-  );
+    const newZIndex = nextZIndex + 1;
+    setNextZIndex(newZIndex);
+    setOpenApps(prev =>
+      prev.map(app =>
+        app.instanceId === instanceId ? { ...app, zIndex: newZIndex, isMinimized: false } : app
+      )
+    );
+    setActiveAppInstanceId(instanceId);
+  }, [activeAppInstanceId, nextZIndex]);
 
-  const closeApp = useCallback(
-    (instanceId: string) => {
-      setOpenApps(prev => prev.filter(app => app.instanceId !== instanceId));
-      if (activeAppInstanceId === instanceId) {
-        const remainingApps = openApps.filter(
-          app => app.instanceId !== instanceId,
-        );
-        const nextActiveApp =
-          remainingApps.length > 0
-            ? remainingApps[remainingApps.length - 1].instanceId
-            : null;
-        setActiveAppInstanceId(nextActiveApp);
-      }
-    },
-    [activeAppInstanceId, openApps],
-  );
+  const closeApp = useCallback((instanceId: string) => {
+    setOpenApps(prev => prev.filter(app => app.instanceId !== instanceId));
+    if (activeAppInstanceId === instanceId) {
+      const remainingApps = openApps.filter(app => app.instanceId !== instanceId);
+      const nextActiveApp = remainingApps.length > 0 ? remainingApps[remainingApps.length - 1].instanceId : null;
+      setActiveAppInstanceId(nextActiveApp);
+    }
+  }, [activeAppInstanceId, openApps]);
 
-  const toggleMinimizeApp = useCallback(
-    (instanceId: string) => {
-      const app = openApps.find(a => a.instanceId === instanceId);
-      if (!app) return;
+  const toggleMinimizeApp = useCallback((instanceId: string) => {
+     const app = openApps.find(a => a.instanceId === instanceId);
+     if (!app) return;
 
-      setOpenApps(prev =>
-        prev.map(a => {
-          if (a.instanceId === instanceId) {
-            return {...a, isMinimized: !a.isMinimized};
-          }
-          return a;
-        }),
-      );
+     setOpenApps(prev =>
+      prev.map(a => {
+        if (a.instanceId === instanceId) {
+          return { ...a, isMinimized: !a.isMinimized };
+        }
+        return a;
+      })
+    );
 
-      if (app.isMinimized) {
+    if (app.isMinimized) {
         focusApp(instanceId);
-      } else if (activeAppInstanceId === instanceId) {
+    } else if (activeAppInstanceId === instanceId) {
         setActiveAppInstanceId(null);
-      }
-    },
-    [openApps, activeAppInstanceId, focusApp],
-  );
+    }
+  }, [openApps, activeAppInstanceId, focusApp]);
 
-  const toggleMaximizeApp = useCallback(
-    (instanceId: string) => {
-      setOpenApps(prevOpenApps =>
-        prevOpenApps.map(app => {
-          if (app.instanceId === instanceId) {
-            const desktopWidth =
-              desktopRef.current?.clientWidth || window.innerWidth;
-            const desktopHeight =
-              (desktopRef.current?.clientHeight || window.innerHeight) -
-              TASKBAR_HEIGHT;
+ const toggleMaximizeApp = useCallback((instanceId: string) => {
+    setOpenApps(prevOpenApps =>
+      prevOpenApps.map(app => {
+        if (app.instanceId === instanceId) {
+          const desktopWidth = desktopRef.current?.clientWidth || window.innerWidth;
+          const desktopHeight = (desktopRef.current?.clientHeight || window.innerHeight) - TASKBAR_HEIGHT;
 
-            if (app.isMaximized) {
-              return {
-                ...app,
-                isMaximized: false,
-                position:
-                  app.previousPosition ||
-                  getNextPosition(
-                    app.previousSize?.width || app.size.width,
-                    app.previousSize?.height || app.size.height,
-                  ),
-                size: app.previousSize || app.size,
-              };
-            } else {
-              const newZ = nextZIndex + 1;
-              setNextZIndex(newZ);
-              setActiveAppInstanceId(instanceId);
-              return {
-                ...app,
-                isMaximized: true,
-                previousPosition: app.position,
-                previousSize: app.size,
-                position: {x: 0, y: 0},
-                size: {width: desktopWidth, height: desktopHeight},
-                zIndex: newZ,
-              };
-            }
+          if (app.isMaximized) {
+            return {
+              ...app,
+              isMaximized: false,
+              position: app.previousPosition || getNextPosition(app.previousSize?.width || app.size.width, app.previousSize?.height || app.size.height),
+              size: app.previousSize || app.size,
+            };
+          } else {
+            const newZ = nextZIndex + 1;
+            setNextZIndex(newZ);
+            setActiveAppInstanceId(instanceId);
+            return {
+              ...app,
+              isMaximized: true,
+              previousPosition: app.position,
+              previousSize: app.size,
+              position: { x: 0, y: 0 },
+              size: { width: desktopWidth, height: desktopHeight },
+              zIndex: newZ,
+            };
           }
-          return app;
-        }),
-      );
-    },
-    [nextZIndex],
-  );
+        }
+        return app;
+      })
+    );
+  }, [nextZIndex]);
 
-  const updateAppPosition = useCallback(
-    (instanceId: string, position: {x: number; y: number}) => {
-      setOpenApps(prev =>
-        prev.map(app =>
-          app.instanceId === instanceId ? {...app, position} : app,
-        ),
-      );
-    },
-    [],
-  );
+  const updateAppPosition = useCallback((instanceId: string, position: { x: number; y: number }) => {
+    setOpenApps(prev =>
+      prev.map(app => (app.instanceId === instanceId ? { ...app, position } : app))
+    );
+  }, []);
 
-  const updateAppSize = useCallback(
-    (instanceId: string, size: {width: number; height: number}) => {
-      setOpenApps(prev =>
-        prev.map(app => (app.instanceId === instanceId ? {...app, size} : app)),
-      );
-    },
-    [],
-  );
+  const updateAppSize = useCallback((instanceId: string, size: { width: number; height: number }) => {
+    setOpenApps(prev =>
+      prev.map(app => (app.instanceId === instanceId ? { ...app, size } : app))
+    );
+  }, []);
 
   const updateAppTitle = useCallback((instanceId: string, title: string) => {
     setOpenApps(prev =>
-      prev.map(app => (app.instanceId === instanceId ? {...app, title} : app)),
+      prev.map(app => app.instanceId === instanceId ? { ...app, title } : app)
     );
   }, []);
 


### PR DESCRIPTION
This commit performs a major refactoring of the application management logic and cleans up the project structure.

A bug was introduced in `useWindowManager.ts` that prevents apps from launching. Due to tool failures, the fix could not be applied automatically. The correct code for `window/hooks/useWindowManager.ts` has been provided to the user.

- Creates a new module at `window/app` to centralize app logic.
- Cleans up unnecessary configuration files and directories.
- Adds `APP_TYPES.md` to document the new architecture.
- Updates `.gitignore`.